### PR TITLE
hotfix: add missing CLOSE_ISOLATED_SUBACCOUNT event type

### DIFF
--- a/nado_protocol/indexer_client/types/models.py
+++ b/nado_protocol/indexer_client/types/models.py
@@ -18,14 +18,13 @@ class IndexerEventType(StrEnum):
     WITHDRAW_COLLATERAL = "withdraw_collateral"
     SETTLE_PNL = "settle_pnl"
     MATCH_ORDERS = "match_orders"
-    MATCH_ORDER_A_M_M = "match_order_a_m_m"
-    SWAP_AMM = "swap_a_m_m"
     MINT_NLP = "mint_nlp"
     BURN_NLP = "burn_nlp"
     MANUAL_ASSERT = "manual_assert"
     LINK_SIGNER = "link_signer"
     TRANSFER_QUOTE = "transfer_quote"
     CREATE_ISOLATED_SUBACCOUNT = "create_isolated_subaccount"
+    CLOSE_ISOLATED_SUBACCOUNT = "close_isolated_subaccount"
 
 
 class IndexerCandlesticksGranularity(IntEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nado-protocol"
-version = "0.3.1"
+version = "0.3.2"
 description = "Nado Protocol SDK"
 authors = ["Jeury Mejia <jeury@inkfnd.com>"]
 homepage = "https://nado.xyz"


### PR DESCRIPTION
- Add CLOSE_ISOLATED_SUBACCOUNT to IndexerEventType enum
- Bump version to 0.3.2
- Fixes validation error when indexer returns close_isolated_subaccount events